### PR TITLE
fixed linter rules, ignore package.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,6 +37,7 @@
     "react/jsx-props-no-spreading": "off",
     "no-console": ["error", { "allow": ["warn"] }],
     "object-curly-newline": "off",
+    "arrow-parens": [2, "as-needed"],
     "no-unused-expressions": [
       "error",
       {

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ web-build/
 .env
 yarn-error.log
 coverage/
+package.json
 
 # macOS
 .DS_Store

--- a/src/database/firebase.tsx
+++ b/src/database/firebase.tsx
@@ -83,7 +83,8 @@ export const setTree = async (tree: Tree) => {
 };
 
 /**
- * getComment queries the `comments` table and returns a Comment if the ID is found and an empty entry otherwise.
+ * getComment queries the `comments` table and
+ * returns a Comment if the ID is found and an empty entry otherwise.
  */
 export const getComment = async (id: string): Promise<Comment> => {
   try {
@@ -110,7 +111,8 @@ export const setComment = async (comment: Comment) => {
 };
 
 /**
- * getAdditional queries the `additional` table and returns an Additional if the ID is found and an empty entry otherwise.
+ * getAdditional queries the `additional` table and
+ * returns an Additional if the ID is found and an empty entry otherwise.
  */
 export const getAdditional = async (id: string): Promise<Additional> => {
   try {


### PR DESCRIPTION
## Summary
- disabled arrow parens eg `(a) => b` is not valid
- added package.json to .gitignore