### PR TITLE
Switch unique key to uuid and remove destructuring from firebase setters

### DIFF
--- a/src/database/firebase.tsx
+++ b/src/database/firebase.tsx
@@ -75,7 +75,7 @@ export const getAllTrees = async (): Promise<Tree[]> => {
  */
 export const setTree = async (tree: Tree) => {
   try {
-    await treeCollection.doc(tree.uuid).set({ tree });
+    await treeCollection.doc(tree.uuid).set(tree);
   } catch (e) {
     console.warn(e);
     throw e;
@@ -103,7 +103,7 @@ export const getComment = async (uuid: string): Promise<Comment> => {
  */
 export const setComment = async (comment: Comment) => {
   try {
-    await commentCollection.doc(comment.uuid).set({ comment });
+    await commentCollection.doc(comment.uuid).set(comment);
   } catch (e) {
     console.warn(e);
     throw e;
@@ -131,7 +131,7 @@ export const getAdditional = async (uuid: string): Promise<Additional> => {
  */
 export const setAdditional = async (additional: Additional) => {
   try {
-    await additionalCollection.doc(additional.uuid).set({ additional });
+    await additionalCollection.doc(additional.uuid).set(additional);
   } catch (e) {
     console.warn(e);
     throw e;

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -41,7 +41,7 @@ export default function SearchScreen() {
           value={searchQuery}
         />
         {filtered.map((tree: Tree) => (
-          <SearchCard key={tree.id} name={tree.name} id={tree.id} />
+          <SearchCard key={tree.uuid} name={tree.name} id={tree.id} />
         ))}
       </ScrollView>
     </ViewContainer>


### PR DESCRIPTION
## Summary
- Switched the unique key on SearchCard to use `uuid` which will actually be guaranteed to be unique (since creating new blank trees will leave the `id` field blank so they wouldn't be unique)
- Removed restructuring from firebase setters by request from @mylesdomingo 

## Test Plan
- Make sure you don't get the "Warning: Each child in a list should have a unique "key" prop."" in expo on SearchScreen (make sure Firebase is properly cleaned up though)

## Other
### Next Steps
n/a

### Relevant Links
n/a

### Online Sources
n/a

### Related PRs
n/a

## Screenshots and Tests
n/a


CC: @mylesdomingo
