### PR TITLE
[View/Edit Trees] Create TreeDetails screen and migrate Edit functionality

### DIFF
--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -9,9 +9,9 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import { RootStackParamList } from '@types';
-import EditScreen from 'screens/EditScreen';
 import ModalScreen from 'screens/ModalScreen';
 import NotFoundScreen from 'screens/NotFoundScreen';
+import TreeDetailsScreen from 'src/screens/TreeDetailsScreen';
 
 import LinkingConfiguration from './LinkingConfiguration';
 import TabNavigator from './TabNavigator';
@@ -32,9 +32,11 @@ function RootNavigator() {
         options={{ headerShown: false }}
       />
       <Screen
-        name="Edit"
-        component={EditScreen}
-        options={{ headerShown: false }}
+        name="TreeDetails"
+        component={TreeDetailsScreen}
+        options={{
+          title: 'View Tree',
+        }}
       />
       <Screen
         name="NotFound"

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -56,7 +56,7 @@ export default function SearchScreen({
               key={uuid}
               name={name}
               id={id}
-              onPress={() => navigation.push('Edit', { uuid })}
+              onPress={() => navigation.push('TreeDetails', { uuid })}
             />
           );
         })}

--- a/src/screens/TreeDetailsScreen.tsx
+++ b/src/screens/TreeDetailsScreen.tsx
@@ -2,11 +2,11 @@ import React, { useEffect, useState } from 'react';
 
 import PropTypes from 'prop-types';
 import { StyleSheet, Button } from 'react-native';
-import { Title, TextInput } from 'react-native-paper';
+import { IconButton, TextInput } from 'react-native-paper';
 
 import { RootStackScreenProps, Tree } from '@types';
 import ViewContainer from 'components/ViewContainer';
-import { getTree, checkID, setTree } from 'src/database/firebase';
+import { getTree, setTree } from 'src/database/firebase';
 
 const styles = StyleSheet.create({
   input: {
@@ -20,10 +20,10 @@ const styles = StyleSheet.create({
   },
 });
 
-export default function EditScreen({
+export default function TreeDetailsScreen({
   route,
   navigation,
-}: RootStackScreenProps<'Edit'>) {
+}: RootStackScreenProps<'TreeDetails'>) {
   // @ts-ignore
   const { uuid } = route.params;
   const [entry, setEntry] = useState<Tree>({
@@ -33,6 +33,9 @@ export default function EditScreen({
     location: null,
     planted: null,
   });
+
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+
   useEffect(() => {
     async function getEntry() {
       const data = await getTree(uuid);
@@ -40,32 +43,52 @@ export default function EditScreen({
     }
     getEntry();
   }, [uuid]);
-  const onPress = () => {
-    setTree(entry);
-    navigation.goBack();
+
+  const toggleEditing = () => {
+    if (isEditing) {
+      setIsEditing(false);
+      navigation.setOptions({
+        title: 'View Tree',
+      });
+    } else {
+      setIsEditing(true);
+      navigation.setOptions({
+        title: 'Edit Tree',
+      });
+    }
   };
+
+  const handleSaveChanges = () => {
+    setTree(entry);
+    toggleEditing();
+  };
+
+  navigation.setOptions({
+    headerRight: () => <IconButton icon="pencil" onPress={toggleEditing} />,
+  });
 
   return (
     <ViewContainer>
-      <Title>Edit Screen</Title>
       <TextInput
+        disabled={!isEditing}
         label="Name"
-        value={entry.name}
         onChangeText={value => setEntry({ ...entry, name: value.toString() })}
         style={styles.input}
+        value={entry.name ?? ''}
       />
       <TextInput
+        disabled={!isEditing}
         label="ID"
-        value={entry.id}
         onChangeText={value => setEntry({ ...entry, id: value.toString() })}
         style={styles.input}
+        value={entry.id}
       />
-      <Button title="Submit Tree" onPress={onPress} />
+      {isEditing && <Button title="Save Changes" onPress={handleSaveChanges} />}
     </ViewContainer>
   );
 }
 
-EditScreen.propTypes = {
+TreeDetailsScreen.propTypes = {
   route: PropTypes.shape({
     params: PropTypes.shape({
       uuid: PropTypes.string.isRequired,
@@ -73,5 +96,6 @@ EditScreen.propTypes = {
   }).isRequired,
   navigation: PropTypes.shape({
     goBack: PropTypes.func.isRequired,
+    setOptions: PropTypes.func.isRequired,
   }).isRequired,
 };

--- a/types.tsx
+++ b/types.tsx
@@ -20,7 +20,7 @@ export type RootStackParamList = {
   Root: NavigatorScreenParams<RootTabParamList> | undefined;
   Modal: undefined;
   NotFound: undefined;
-  Edit: any;
+  TreeDetails: any;
 };
 
 export type RootStackScreenProps<Screen extends keyof RootStackParamList> =


### PR DESCRIPTION
## Summary
Converted `EditScreen` into `TreeDetailsScreen` and added an Edit button to the menu bar to toggle edit mode. Now `TreeDetailsScreen` can be used as the generic tree screen with an editing mode.

## Test Plan
- Try viewing and editing a tree

## Other
### Next Steps
- Styilng
- Adding support for deep linking from QR code scanning to open a tree detail screen
 
### Relevant Links
### Online Sources
https://reactnavigation.org/docs/headers/#updating-options-with-setoptions

### Related PRs
Builds off of #28 

## Screenshots and Tests
![IMG_6112](https://user-images.githubusercontent.com/21160510/139191584-76f9d9d6-d1ba-4bb8-8314-8f65929da7f0.PNG)
![IMG_B3BE72778F0E-1](https://user-images.githubusercontent.com/21160510/139191533-9d5eeb45-9f99-4eb0-bb30-5032d11ff542.jpeg)

CC: @mylesdomingo
