### PR TITLE
Add support for staying logged with phone auth & basic logout functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^12.0.0",
-    "@react-native-community/async-storage": "^1.12.1",
+    "@react-native-async-storage/async-storage": "~1.15.0",
     "@react-native-firebase/app": "^12.7.5",
     "@react-navigation/bottom-tabs": "^6.0.5",
     "@react-navigation/core": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^12.0.0",
+    "@react-native-community/async-storage": "^1.12.1",
     "@react-native-firebase/app": "^12.7.5",
     "@react-navigation/bottom-tabs": "^6.0.5",
+    "@react-navigation/core": "^6.1.0",
     "@react-navigation/native": "^6.0.2",
     "@react-navigation/native-stack": "^6.1.0",
     "@types/react-native-dotenv": "^0.2.0",

--- a/src/components/ViewContainer.tsx
+++ b/src/components/ViewContainer.tsx
@@ -2,23 +2,28 @@ import * as React from 'react';
 
 import { StyleSheet, View } from 'react-native';
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    backgroundColor: '#fff',
-  },
-});
-
 type ViewProps = {
   children?: React.ReactNode;
+  topPadding?: boolean;
 };
 
+const styles = (props: ViewProps) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      alignItems: 'center',
+      backgroundColor: '#fff',
+      paddingTop: props.topPadding ? 48 : 0,
+    },
+  });
+
 export default function ViewContainer(props: ViewProps) {
+  const classes = styles(props);
   const { children } = props;
-  return <View style={styles.container}>{children}</View>;
+  return <View style={classes.container}>{children}</View>;
 }
 
 ViewContainer.defaultProps = {
   children: null,
+  topPadding: false,
 };

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
 import { RootTabParamList, RootTabScreenProps } from '@types';

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import AsyncStorage from '@react-native-community/async-storage';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 
 import { RootTabParamList, RootTabScreenProps } from '@types';
@@ -27,8 +28,11 @@ export default function TabNavigator() {
           tabBarIcon: ({ color }) => <Icon name="home" color={color} />,
           headerRight: () => (
             <Icon
-              name="info-circle"
-              onPress={() => navigation.navigate('Modal')}
+              name="sign-out"
+              onPress={async () => {
+                await AsyncStorage.removeItem('userToken');
+                navigation.navigate('AuthLoading');
+              }}
               size={25}
               style={{ marginRight: 15 }}
             />

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -11,6 +11,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { RootStackParamList } from '@types';
 import ModalScreen from 'screens/ModalScreen';
 import NotFoundScreen from 'screens/NotFoundScreen';
+import AuthLoadingScreen from 'src/screens/AuthLoadingScreen';
 import LoginScreen from 'src/screens/LoginScreen';
 import TreeDetailsScreen from 'src/screens/TreeDetailsScreen';
 import VerificationScreen from 'src/screens/VerificationScreen';
@@ -27,13 +28,25 @@ function RootNavigator() {
   const { Navigator, Screen, Group } = Stack;
 
   return (
-    <Navigator>
-      <Screen name="Login" component={LoginScreen} />
+    <Navigator initialRouteName="AuthLoading">
+      <Screen
+        name="AuthLoading"
+        component={AuthLoadingScreen}
+        options={{
+          headerShown: false,
+          gestureEnabled: false,
+        }}
+      />
+      <Screen
+        name="Login"
+        options={{ headerShown: false, gestureEnabled: false }}
+        component={LoginScreen}
+      />
       <Screen name="Verify" component={VerificationScreen} />
       <Screen
         name="Root"
         component={TabNavigator}
-        options={{ headerShown: false }}
+        options={{ headerShown: false, gestureEnabled: false }}
       />
       <Screen
         name="TreeDetails"

--- a/src/screens/AuthLoadingScreen.tsx
+++ b/src/screens/AuthLoadingScreen.tsx
@@ -1,4 +1,4 @@
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useFocusEffect } from '@react-navigation/core';
 
 export default function AuthLoadingScreen({ navigation }) {

--- a/src/screens/AuthLoadingScreen.tsx
+++ b/src/screens/AuthLoadingScreen.tsx
@@ -1,0 +1,14 @@
+import AsyncStorage from '@react-native-community/async-storage';
+import { useFocusEffect } from '@react-navigation/core';
+
+export default function AuthLoadingScreen({ navigation }) {
+  useFocusEffect(() => {
+    async function getUserToken() {
+      const userToken = await AsyncStorage.getItem('userToken');
+      navigation.navigate(userToken ? 'Root' : 'Login');
+    }
+    getUserToken();
+  });
+
+  return null;
+}

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -6,7 +6,7 @@ import {
   FirebaseRecaptchaVerifierModal,
 } from 'expo-firebase-recaptcha';
 import firebase from 'firebase';
-import { Text, View, Button, StyleSheet, TouchableOpacity } from 'react-native';
+import { Button, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { Title } from 'react-native-paper';
 import { isPossiblePhoneNumber } from 'react-phone-number-input';
 import PhoneInput from 'react-phone-number-input/react-native-input';
@@ -49,7 +49,7 @@ export default function Login({ navigation }) {
     }
   }
   return (
-    <ViewContainer>
+    <ViewContainer topPadding>
       <Title>Login Screen</Title>
       <View style={styles.separator} />
       <FirebaseRecaptchaVerifierModal

--- a/src/screens/VerificationScreen.tsx
+++ b/src/screens/VerificationScreen.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
+import AsyncStorage from '@react-native-community/async-storage';
 import firebase from 'firebase';
-import PropTypes from 'prop-types';
 import {
   Text,
   View,
@@ -49,6 +49,7 @@ export default function Verify({ route, navigation }) {
               verificationId,
               verificationCode,
             );
+            await AsyncStorage.setItem('userToken', credential.providerId);
             await firebase.auth().signInWithCredential(credential);
             showMessage({ text: 'Phone authentication successful' });
             navigation.navigate('Root');

--- a/src/screens/VerificationScreen.tsx
+++ b/src/screens/VerificationScreen.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import firebase from 'firebase';
 import {
   Text,

--- a/types.tsx
+++ b/types.tsx
@@ -17,6 +17,7 @@ declare global {
 }
 // TODO: add strong typing for react navigation props
 export type RootStackParamList = {
+  AuthLoading: undefined;
   Root: NavigatorScreenParams<RootTabParamList> | undefined;
   Modal: undefined;
   NotFound: undefined;


### PR DESCRIPTION
## Summary
- Resolved #46 with the ability for users to stay logged in after authenticating for the first time by storing a user token upon successful phone auth login to AsyncStorage
  - Note: I'm storing what is returned from `credential.providerId` from Firebase, which is literally `'phone'`. We should probably store the user's `uid` later down the road.
  - `AuthLoadingScreen` (shoutout to [DC Central Kitchen](https://github.com/calblueprint/dccentralkitchen/blob/441b6e1493aa683272e9a104c9b8c0917fc23752/screens/auth/AuthLoadingScreen.js)) checks if the token is set in AsyncStorage and determines whether to navigate to `Login` or `Root`.
- Added ability to log out (I just made it the button on the top right on the home screen) which clears the token from AsyncStorage and navigates back to `AuthLoadingScreen`

## Test Plan
**Staying Logged In**
1. Log in using phone auth
2. Close Expo
3. Open the app again
4. You should be taken straight to the map screen
 
**Log out**
1. On the map screen, click the exit button on the top right to log out
2. You should be taken back to LoginScreen
3. If you close and open expo again, you should still be taken to LoginScreen.

## Other
### Next Steps
- Set `userToken` to be something user-specific
- Get rid of the obvious transition between `AuthLoadingScreen` and the next screens
- Clean up logout function

### Relevant Links
https://github.com/calblueprint/dccentralkitchen/blob/441b6e1493aa683272e9a104c9b8c0917fc23752/screens/auth/AuthLoadingScreen.js

(dcck 4 lyfe)
### Online Sources
n/a

### Related PRs
n/a

## Screenshots and Tests
Loom is not cooperating so I can't get a screen recording going unfortunately.

CC: @mylesdomingo
