### PR TITLE
Make bottom tab navigator buttons and icons fully pressable

### DIFF
--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -32,6 +32,7 @@ export default function Icon(props: IconProps) {
 
   return (
     <Pressable
+      disabled={!onPress}
       onPress={onPress ?? null}
       style={({ pressed }) => (pressed ? styles.opaque : styles.fade)}
     >


### PR DESCRIPTION
## Summary
Resolved #35 by making the whole icon area pressable in the bottom tab navigator.

## Test Plan
- Click anywhere on the icon/text and it should navigate properly!

## Other
### Next Steps
n/a

### Relevant Links
n/a

### Online Sources
n/a

### Related PRs
n/a

## Screenshots and Tests
Couldn't make a screen recording bc no space on my disk but TRUST ME

CC: @mylesdomingo
