### PR TITLE
[Edit Tree] Add ability to archive/unarchive a tree

### DIFF
--- a/src/database/firebase.js
+++ b/src/database/firebase.js
@@ -101,6 +101,20 @@ export const getAllTrees = async () => {
 };
 
 /**
+ * getInactiveTrees returns an array of all Trees with state prop 'active' set to false.
+ */
+export const getInactiveTrees = async () => {
+  try {
+    const response = await treeCollection.where('active', '==', false).get();
+    return response.docs.map(doc => doc.data());
+  } catch (e) {
+    console.warn(e);
+    throw e;
+    // TODO: Add error handling
+  }
+};
+
+/**
  * setTree creates/updates an entry in the `trees` table given a Tree.
  */
 export const setTree = async tree => {

--- a/src/database/firebase.js
+++ b/src/database/firebase.js
@@ -72,6 +72,21 @@ export const getTree = async uuid => {
 };
 
 /**
+ * getActiveTrees returns an array of all Trees with state prop 'active' set to true.
+ * @param tree
+ */
+export const getActiveTrees = async () => {
+  try {
+    const response = await treeCollection.where('active', '==', true).get();
+    return response.docs.map(doc => doc.data());
+  } catch (e) {
+    console.warn(e);
+    throw e;
+    // TODO: Add error handling
+  }
+};
+
+/**
  * getAllTrees returns an array containing all entries in the `trees` table.
  */
 export const getAllTrees = async () => {

--- a/src/screens/AddScreen.js
+++ b/src/screens/AddScreen.js
@@ -25,6 +25,7 @@ export default function AddScreen() {
     location: null,
     planted: null,
     comment: null,
+    active: true,
   });
   const [location, setLocation] = useState({
     latitude: DEFAULT_LOCATION.latitude,

--- a/src/screens/SearchScreen.js
+++ b/src/screens/SearchScreen.js
@@ -15,6 +15,7 @@ export default function SearchScreen({ navigation }) {
   const [active, setActive] = useState(true);
   const filtered = trees
     .filter(tree => !active || tree.active)
+    .filter(tree => active || !tree.active)
     .filter(tree => tree !== null && tree.name && tree.id && checkID(tree.uuid))
     .filter(tree => {
       const query = searchQuery.toLowerCase();
@@ -55,7 +56,7 @@ export default function SearchScreen({ navigation }) {
           </Text>
         </Inset>
         <Button
-          title={!active ? 'Show All Trees' : 'Show Active Trees'}
+          title={!active ? 'Show Active Trees' : 'Show Inactive Trees'}
           onPress={() => {
             setActive(!active);
           }}

--- a/src/screens/SearchScreen.js
+++ b/src/screens/SearchScreen.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { func, shape } from 'prop-types';
-import { ScrollView, Text } from 'react-native';
+import { ScrollView, Text, Button } from 'react-native';
 import { Searchbar } from 'react-native-paper';
 
 import Inset from '../components/Inset';
@@ -12,7 +12,9 @@ import { getAllTrees, checkID } from '../database/firebase';
 export default function SearchScreen({ navigation }) {
   const [searchQuery, setSearchQuery] = useState('');
   const [trees, setTrees] = useState([]);
+  const [active, setActive] = useState(true);
   const filtered = trees
+    .filter(tree => !active || tree.active)
     .filter(tree => tree !== null && tree.name && tree.id && checkID(tree.uuid))
     .filter(tree => {
       const query = searchQuery.toLowerCase();
@@ -52,6 +54,12 @@ export default function SearchScreen({ navigation }) {
             Search
           </Text>
         </Inset>
+        <Button
+          title={!active ? 'Show All Trees' : 'Show Active Trees'}
+          onPress={() => {
+            setActive(!active);
+          }}
+        />
         <Searchbar
           style={{ minWidth: '100%', shadowOpacity: 0 }}
           placeholder="Search"

--- a/src/screens/TreeDetailsScreen.js
+++ b/src/screens/TreeDetailsScreen.js
@@ -36,6 +36,7 @@ export default function TreeDetailsScreen({ route, navigation }) {
     uuid: '',
     location: null,
     planted: null,
+    active: true,
     comments: [],
   });
 
@@ -91,6 +92,12 @@ export default function TreeDetailsScreen({ route, navigation }) {
         style={styles.input}
         value={entry.id}
       />
+      {isEditing && (
+        <Button
+          title={entry.active ? 'Archive tree' : 'Unarchive tree'}
+          onPress={() => setEntry({ ...entry, active: !entry.active })}
+        />
+      )}
       {isEditing && <Button title="Save Changes" onPress={handleSaveChanges} />}
 
       {entry.comments?.map((c, i) => (


### PR DESCRIPTION
## Summary
**What does this PR contribute?**

1. This PR allows functionality to archive Trees by enabling an active feature. 
2. Added a feature to toggle between active and inactive (archived) tree lists in the Search Screen. 
3. Previously when the "Show Active Trees" toggle was pressed, the Inactive Trees were shown and vice-versa. This has been corrected.

## Test Plan
**How should the person reviewing this PR test it out? For example, what screens in the app should they go to?**
Select an active tree and enter the Edit page. Select the "Archive tree" button. On top of the "Search" page toggle between active trees and inactive trees.

## Notes
Now that the ability to archive trees exists, we can fine-tune the "save changes" feature to become more prominent. I realized the bug existed when I pressed the button multiple times because I did not know if it applied the changes. Found multiple copies of the tree. 

I also noticed a slight delay in the active/inactive tree lists after a tree was updated. 

### Next Steps

1. Peer Review of this PR.
2. Look into lag fix.

### Relevant Links

### Online Sources


### Related PRs

## Screenshots and Tests
If your feature is visual, attach before/after screenshots and ensure that tests still pass

https://user-images.githubusercontent.com/65273615/156739329-2bad5624-35eb-49fb-a0eb-f70dfc953da1.MP4


https://user-images.githubusercontent.com/65273615/158750432-9fdcdae8-a1f0-4416-9242-50f50ed425b1.mp4
