### PR TITLE
Fix tab bar scroll issue

### DIFF
--- a/src/navigation/TabNavigator.js
+++ b/src/navigation/TabNavigator.js
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { BlurView } from 'expo-blur';
-import { StyleSheet } from 'react-native';
 
 import Icon from '../components/Icon';
 import AddScreen from '../screens/AddScreen';

--- a/src/navigation/TabNavigator.js
+++ b/src/navigation/TabNavigator.js
@@ -22,14 +22,6 @@ export default function TabNavigator() {
       initialRouteName="Home"
       screenOptions={{
         tabBarActiveTintColor: '#52bd41',
-        tabBarStyle: { position: 'absolute', height: 80 },
-        tabBarBackground: () => (
-          <BlurView
-            tint="light"
-            intensity={100}
-            style={StyleSheet.absoluteFill}
-          />
-        ),
       }}
     >
       <Screen


### PR DESCRIPTION
## Summary
The tab bar was earlier set to `position: absolute`, as a result of which content on our screens was getting clipped at the bottom. This removes that, so that content doesn't get clipped and ScrollViews work properly.

## Test Plan
Already tested at Bug Bash!

## Notes
(You can leave this empty if you don't have anything.)

### Next Steps

### Relevant Links

### Online Sources

### Related PRs

## Screenshots and Tests
If your feature is visual, attach before/after screenshots and ensure that tests still pass
