### PR TITLE
[Map View] Tree Cards Android Fix

### DIFF
--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -119,6 +119,7 @@ export default function HomeScreen({ navigation }) {
         <MapScreen
           data={filtered}
           navigation={navigation}
+          isList={isListView}
           style={{
             position: 'absolute',
             zIndex: 2,

--- a/src/screens/MapScreen.js
+++ b/src/screens/MapScreen.js
@@ -1,12 +1,16 @@
 import React, { useState } from 'react';
 
-import { arrayOf, func, shape } from 'prop-types';
-import { StyleSheet, ViewPropTypes, View } from 'react-native';
+import { arrayOf, bool, func, shape } from 'prop-types';
+import { Platform, StyleSheet, ViewPropTypes, View } from 'react-native';
 import MapView, { Marker, PROVIDER_GOOGLE } from 'react-native-maps';
 
 import SearchCard from '../components/SearchCard';
 import { DEFAULT_LOCATION } from '../constants/DefaultLocation';
 import Tree from '../customprops';
+
+const check = {
+  isAndroid: () => Platform.OS === 'android',
+};
 
 const styles = StyleSheet.create({
   map: {
@@ -29,14 +33,14 @@ const styles = StyleSheet.create({
   },
   card: {
     width: '100%',
-    bottom: 60,
+    bottom: check.isAndroid ? -20 : 60,
     position: 'absolute',
     zIndex: 500,
   },
 });
 
 // eslint-disable-next-line no-unused-vars
-export default function MapScreen({ style, navigation, data }) {
+export default function MapScreen({ style, navigation, data, isList }) {
   const [active, setActive] = useState(null);
 
   return (
@@ -48,6 +52,7 @@ export default function MapScreen({ style, navigation, data }) {
         mapType="satellite"
         maxZoomLevel={25}
         showsUserLocation
+        toolbarEnabled={false}
       >
         {data.map(tree => (
           <Marker
@@ -66,26 +71,28 @@ export default function MapScreen({ style, navigation, data }) {
             pinColor={tree.uuid === active?.uuid ? '#f00' : '#0f0'}
           />
         ))}
-        <View style={styles.card}>
-          {active && (
-            <SearchCard
-              key={active.uuid}
-              name={active.name}
-              comments={active.comments}
-              onPress={() => {
-                navigation.push('TreeScreen', { uuid: active.uuid });
-              }}
-            />
-          )}
-        </View>
       </MapView>
+      <View style={styles.card}>
+        {active && !isList && (
+          <SearchCard
+            key={active.uuid}
+            name={active.name}
+            comments={active.comments}
+            onPress={() => {
+              navigation.push('TreeScreen', { uuid: active.uuid });
+            }}
+          />
+        )}
+      </View>
     </View>
   );
 }
+
 MapScreen.propTypes = {
   style: ViewPropTypes.style,
   data: arrayOf(Tree),
   navigation: shape({
     push: func,
   }),
+  isList: bool,
 };


### PR DESCRIPTION
## Summary
When a map marker is pressed (i.e. the pins demarcating specific trees on the farm), the corresponding card (displaying tree image and name) pops up. OnPress was happening for Android, but cards were not being displayed on Android.

## Test Plan
Try pressing the different tree pins and check that the appropriate tree card shows up.
Make sure that card margins/padding looks good.
Make sure that card pops down when toggling from MapView to ListView.

## Notes
Not sure how these fixes for Android affect IOS, hopefully this feature works for both now.

### Next Steps

### Relevant Links

### Online Sources

### Related PRs

## Screenshots and Tests

https://user-images.githubusercontent.com/78326649/165637558-abfa3888-340d-4bf4-92c2-c4a620ae4189.mp4


